### PR TITLE
Reverse before left-folding, to preserve property order.

### DIFF
--- a/library/src/main/scala/maven.scala
+++ b/library/src/main/scala/maven.scala
@@ -48,7 +48,7 @@ object Maven extends JavaTokenParsers {
       case (k, value)            => k -> Right(value)
     }
     val initial: Either[String, G8.OrderedProperties] = Right(List.empty)
-    defaults.foldLeft(initial) {
+    defaults.reverseIterator.foldLeft(initial) {
       case (accumEither, (k, either)) =>
         for {
           cur   <- accumEither.right


### PR DESCRIPTION
Since properties can refer to each other, order is significant. If we
are going to prepend to a list inside a foldLeft, we need to reverse
before or after.

Fixes #151