### PR TITLE
file/directory property multi-format

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -219,11 +219,14 @@ A `name` field with a value of `My Project` could be rendered in several ways:
 Note that multiple format options can be specified (comma-separated) which will
 be applied in the order given.
 
-For file and directory names a format option can be specified after a double
+For file and directory names formatting options can be specified after a double
 underscore. For example, a directory named `$organization__packaged$` will
 change `org.somewhere` to `org/somewhere` like the built-in support for
 `package`. A file named `$name__Camel$.scala` and the name `awesome project`
-will create the file `AwesomeProject.scala`.
+will create the file `AwesomeProject.scala`. Multiple formatting options can
+be specified by separating them with an underscore. For example,
+`$name__word_lower$.scala` and the name `AWESOME !!` will create the file
+`awesome.scala`.
 
 ### Testing templates locally
 

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -118,7 +118,7 @@ object G8 {
 
     new File(toPath, applyTemplate(formatize(relative), fileParams))
   }
-  private def formatize(s: String) = s.replaceAll("""\$(\w+)__(\w+)\$""", """\$$1;format="$2"\$""")
+  private def formatize(s: String) = s.replaceAll("""\$([^$]+)__([^$]+)\$""", """\$$1;format="$2"\$""")
 
   def decapitalize(s: String) = if (s.isEmpty) s else s(0).toLower + s.substring(1)
   def startCase(s: String) = s.toLowerCase.split(" ").map(_.capitalize).mkString(" ")

--- a/library/src/main/scala/g8.scala
+++ b/library/src/main/scala/g8.scala
@@ -118,7 +118,14 @@ object G8 {
 
     new File(toPath, applyTemplate(formatize(relative), fileParams))
   }
-  private def formatize(s: String) = s.replaceAll("""\$([^$]+)__([^$]+)\$""", """\$$1;format="$2"\$""")
+  val fileFormattedPattern = """\$[^$]+__[^$]+\$""".r
+  private def formatize(s: String) = {
+    val filler = fileFormattedPattern.split(s)
+    val formatized = fileFormattedPattern.findAllMatchIn(s).toList
+      .map(_.toString.split("__"))
+      .map(x=> x(0) + ";format=\"" + x(1).dropRight(1).replaceAll("_", ",") + "\"$")
+    filler.zipAll(formatized, "", "").map(x=>s"${x._1}${x._2}").mkString("")
+  }
 
   def decapitalize(s: String) = if (s.isEmpty) s else s(0).toLower + s.substring(1)
   def startCase(s: String) = s.toLowerCase.split(" ").map(_.capitalize).mkString(" ")


### PR DESCRIPTION
Small change that increases the robustness of the "$property__format$" matching, and also allows multiple formatting options to be specified by separating them with an underscore: "$property__format1_format2$"